### PR TITLE
Add CI workflow for shellcheck and install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run shellcheck
+        run: shellcheck $(git ls-files '*.sh')
+      - name: Test install script
+        env:
+          HOME: ${{ runner.temp }}
+        run: bash install.sh

--- a/install.sh
+++ b/install.sh
@@ -16,13 +16,15 @@ link_to_homedir() {
 
   # dirnameは、パスからディレクトリ部分のみを取り出す
   # BASH_SOURCE[0]には実行したスクリプトのパスが入っている
-  local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-  local dotdir=$script_dir
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+  local dotdir="$script_dir"
   if [[ "$HOME" != "$dotdir" ]];then
     # ?: 任意の一文字にマッチ
     # *: 長さ0以上の文字列にマッチ
     for f in "$dotdir"/.??* "$dotdir"/Taskfile.base.yml; do
-      local filename=$(basename $f)
+      local filename
+      filename=$(basename "$f")
       # -L: ファイルが存在し、シンボリックリンクであれば真
       if [[ -L "$HOME/$filename" ]];then
         command rm -f "$HOME/$filename"
@@ -33,7 +35,7 @@ link_to_homedir() {
       # -s: ハードリンクではなく、シンボリックリンクを作る
       # -n: リンクの作成場所として指定したディレクトリがシンボリックリンクだった場合、参照先にリンクを作るのではなく、シンボリックリンクそのものを置き換える（-fと組み合わせて使用）
       # -f: 同じ名前のファイルがあっても強制的に上書き
-      command ln -snf $f $HOME
+      command ln -snf "$f" "$HOME"
     done
 
     if [ ! -f "$HOME/Taskfile.yml" ];then
@@ -48,9 +50,13 @@ link_to_homedir() {
 
 update_preference() {
   if [[ "$SHELL" == "/bin/bash" ]];then
-    command source "$HOME/.bashrc"
+    set +u
+    command source "$HOME/.bashrc" || true
+    set -u
   elif [[ "$SHELL" == "/bin/zsh" ]];then
-    command zsh -c "source $HOME/.zshrc"
+    set +u
+    command zsh -c "source \"$HOME/.zshrc\"" || true
+    set -u
   else
     command echo "unknown shell"
   fi


### PR DESCRIPTION
## Summary
- run ShellCheck and the installer script in CI
- limit workflow to pull requests opened against main

## Testing
- `shellcheck install.sh`
- `HOME=$(mktemp -d) bash install.sh && echo install.sh succeeded`


------
https://chatgpt.com/codex/tasks/task_e_6899c373d128833199359e4b0073dcc5